### PR TITLE
Fixed bug in Spanish Language Conversion without currency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.0.6
+
+* Fixed bug in Spanish Language Conversion without currency
+
 ## 0.0.5
 
 * Spanish Language Conversion

--- a/lib/src/constants/currency_constants.dart
+++ b/lib/src/constants/currency_constants.dart
@@ -46,8 +46,8 @@ class CurrencyConstants {
 
   /// [spanishCurrencySubunit] and [spanishCurrencySubunitPlural] are used in
   /// [Number2WordsSpanish.convert] method
-  static const String spanishCurrencySubunit = 'cent';
-  static const String spanishCurrencySubunitPlural = 'cents';
+  static const String spanishCurrencySubunit = 'centavo';
+  static const String spanishCurrencySubunitPlural = 'centavos';
 
   /// [englishCurrencySubunit] and [englishCurrencySubunitPlural] are used in [Number2WordsEnglish.convert] method
 }

--- a/lib/src/language/spanish.dart
+++ b/lib/src/language/spanish.dart
@@ -95,15 +95,14 @@ class Number2WordsSpanish {
       text += "${_convert3Numbers(thousands)} mil ";
     }
 
-    if (isCurrency) {
-      if (hundreds != 0) {
-        if (hundreds == 1) {
-          text +=
-              "${_convert3Numbers(hundreds)} ${CurrencyConstants.englishCurrency} ";
-        } else {
-          text +=
-              "${_convert3Numbers(hundreds)}  ${CurrencyConstants.englishCurrencyPlural} ";
-        }
+    if (hundreds != 0) {
+      text += "${_convert3Numbers(hundreds)} ";
+      if (isCurrency && hundreds == 1) {
+        text +=
+            "${CurrencyConstants.spanishCurrencyNative} ";
+      } else if (isCurrency) {
+        text +=
+            " ${CurrencyConstants.spanishCurrencyPluralNative} ";
       }
     }
 
@@ -115,9 +114,9 @@ class Number2WordsSpanish {
       text += _convert3Numbers(decimalPart);
       if (isCurrency) {
         if (decimalPart == 1) {
-          text += ' centavo ';
+          text += ' ${CurrencyConstants.spanishCurrencySubunit} ';
         } else {
-          text += ' centavos ';
+          text += ' ${CurrencyConstants.spanishCurrencySubunitPlural} ';
         }
       }
     }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: number2words
 description: "A new Flutter package for converting numbers to words. This package suits best for multilingual applications and is inspired by the PHP package"
-version: 0.0.5
+version: 0.0.6
 repository: https://github.com/rabinacharya11/number2words
 homepage: https://rabinacharya.info.np
 git: https://github.com/rabinacharya11/number2words

--- a/test/src/language/spanish_test.dart
+++ b/test/src/language/spanish_test.dart
@@ -34,16 +34,17 @@ void main() {
     test('Convert the numbers into words in Lowercase', () {
       /// Defining test cases for the code to be tested
       Map<num, String> testCases = {
-        111: "ciento once dollars ",
-        100: 'cien dollars ',
-        1: 'un dollar ',
-        23: 'veintitrés dollars ',
-        10: 'diez dollars ',
-        999: 'novecientos noventa y nueve dollars ',
+        111: "ciento once dólares ",
+        100: 'cien dólares ',
+        1: 'un dólar ',
+        23: 'veintitrés dólares ',
+        10: 'diez dólares ',
+        999: 'novecientos noventa y nueve dólares ',
+        2604.75: 'dos mil seiscientos cuatro dólares con setenta y cinco centavos ',
         11111111:
-            'once millones ciento once mil ciento once dollars ',
+            'once millones ciento once mil ciento once dólares ',
         111111111111.11:
-            'ciento once mil ciento once millones ciento once mil ciento once dollars con once centavos ',
+            'ciento once mil ciento once millones ciento once mil ciento once dólares con once centavos ',
       };
 
       /// Runing the test cases using a loop
@@ -59,16 +60,16 @@ void main() {
     test('Convert the numbers into words in UpperCase', () {
       /// Defining test cases for the code to be tested
       Map<num, String> testCases = {
-        111: 'ciento once dollars '.toUpperCase(),
-        100: 'cien dollars '.toUpperCase(),
-        1: 'un dollar '.toUpperCase(),
-        23: 'veintitrés dollars '.toUpperCase(),
-        10: 'diez dollars '.toUpperCase(),
-        999: 'novecientos noventa y nueve dollars '.toUpperCase(),
+        111: 'ciento once dólares '.toUpperCase(),
+        100: 'cien dólares '.toUpperCase(),
+        1: 'un dólar '.toUpperCase(),
+        23: 'veintitrés dólares '.toUpperCase(),
+        10: 'diez dólares '.toUpperCase(),
+        999: 'novecientos noventa y nueve dólares '.toUpperCase(),
         11111111:
-            'once millones ciento once mil ciento once dollars '.toUpperCase(),
+            'once millones ciento once mil ciento once dólares '.toUpperCase(),
         111111111111.11:
-            'ciento once mil ciento once millones ciento once mil ciento once dollars con once centavos '
+            'ciento once mil ciento once millones ciento once mil ciento once dólares con once centavos '
               .toUpperCase(),
       };
 
@@ -85,15 +86,15 @@ void main() {
     test('Convert the numbers into words in TitleCase', () {
       /// Defining test cases for the code to be tested
       Map<num, String> testCases = {
-        111: "Ciento Once Dollars ",
-        1: 'Un Dollar ',
-        23: 'Veintitrés Dollars ',
-        10: 'Diez Dollars ',
-        999: 'Novecientos Noventa Y Nueve Dollars ',
+        111: "Ciento Once Dólares ",
+        1: 'Un Dólar ',
+        23: 'Veintitrés Dólares ',
+        10: 'Diez Dólares ',
+        999: 'Novecientos Noventa Y Nueve Dólares ',
         11111111:
-            'Once Millones Ciento Once Mil Ciento Once Dollars ',
+            'Once Millones Ciento Once Mil Ciento Once Dólares ',
         111111111111.11:
-            'Ciento Once Mil Ciento Once Millones Ciento Once Mil Ciento Once Dollars Con Once Centavos ',
+            'Ciento Once Mil Ciento Once Millones Ciento Once Mil Ciento Once Dólares Con Once Centavos ',
       };
 
       /// Runing the test cases using a loop
@@ -109,15 +110,15 @@ void main() {
     test('Convert the numbers into words in Sentence Case', () {
       /// Defining test cases for the code to be tested
       Map<num, String> testCases = {
-        111: "Ciento once dollars ",
-        1: 'Un dollar ',
-        23: 'Veintitrés dollars ',
-        10: 'Diez dollars ',
-        999: 'Novecientos noventa y nueve dollars ',
+        111: "Ciento once dólares ",
+        1: 'Un dólar ',
+        23: 'Veintitrés dólares ',
+        10: 'Diez dólares ',
+        999: 'Novecientos noventa y nueve dólares ',
         11111111:
-            'Once millones ciento once mil ciento once dollars ',
+            'Once millones ciento once mil ciento once dólares ',
         111111111111.11:
-            'Ciento once mil ciento once millones ciento once mil ciento once dollars con once centavos ',
+            'Ciento once mil ciento once millones ciento once mil ciento once dólares con once centavos ',
       };
 
       /// Runing the test cases using a loop


### PR DESCRIPTION
Fixed a bug where the hundreds are skipped when parsing a number with `isCurrency` false